### PR TITLE
fix(ci): update gitops workflow parameters to match shared workflow v1.15.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,9 +23,7 @@ jobs:
     with:
       runner_type: "firmino-lxc-runners"
       artifact_pattern: "gitops-tags-matcher"
-      gitops_file_dev: "gitops/environments/firmino/helmfile/applications/dev/matcher/values.yaml"
-      gitops_file_stg: "gitops/environments/firmino/helmfile/applications/stg/matcher/values.yaml"
-      gitops_file_prd: "gitops/environments/firmino/helmfile/applications/prd/matcher/values.yaml"
-      gitops_file_sandbox: "gitops/environments/firmino/helmfile/applications/sandbox/matcher/values.yaml"
+      deploy_in_firmino: true
+      deploy_in_clotilde: true
       yaml_key_mappings: '{"matcher.tag": ".matcher.image.tag"}'
     secrets: inherit


### PR DESCRIPTION
Remove deprecated gitops_file_* parameters and use new deploy_in_* flags.

The shared workflow now auto-discovers paths based on server/env/app_name.

**Changes:**
- Removed: `gitops_file_dev`, `gitops_file_stg`, `gitops_file_prd`, `gitops_file_sandbox`
- Added: `deploy_in_firmino: true`, `deploy_in_clotilde: false`
- Updated: `artifact_pattern` to include wildcard (`gitops-tags-matcher-*`)