### PR TITLE
fix: treat permission denied as graceful config fallback (distroless nonroot)

### DIFF
--- a/internal/bootstrap/config_yaml.go
+++ b/internal/bootstrap/config_yaml.go
@@ -342,13 +342,15 @@ func loadConfigFromYAML(cfg *Config, filePath string) error {
 	return nil
 }
 
-// isConfigFileNotFound returns true if the error indicates the config file does not exist.
-// Handles both viper's ConfigFileNotFoundError and OS-level file-not-found errors.
+// isConfigFileNotFound returns true if the error indicates the config file cannot be read
+// due to absence or restrictive permissions. In distroless containers, attempting to open
+// a file under a root-owned directory may return EACCES instead of ENOENT. Both cases
+// should fall back gracefully to env-only configuration.
 func isConfigFileNotFound(err error) bool {
 	var notFoundErr viper.ConfigFileNotFoundError
 	if errors.As(err, &notFoundErr) {
 		return true
 	}
 
-	return os.IsNotExist(err)
+	return os.IsNotExist(err) || os.IsPermission(err) || errors.Is(err, os.ErrPermission)
 }

--- a/internal/bootstrap/config_yaml_test.go
+++ b/internal/bootstrap/config_yaml_test.go
@@ -7,6 +7,7 @@
 package bootstrap
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -497,6 +498,16 @@ func TestIsConfigFileNotFound(t *testing.T) {
 		{
 			name:     "viper not found error",
 			err:      viper.ConfigFileNotFoundError{},
+			expected: true,
+		},
+		{
+			name:     "permission denied error",
+			err:      os.ErrPermission,
+			expected: true,
+		},
+		{
+			name:     "wrapped permission denied error",
+			err:      fmt.Errorf("read config: %w", os.ErrPermission),
 			expected: true,
 		},
 		{


### PR DESCRIPTION
## Problem

Matcher crashes on startup in distroless containers:
```
open config/matcher.yaml: permission denied
```

## Root Cause

`isConfigFileNotFound()` only checked for `ENOENT`, not `EACCES`. In distroless:nonroot containers, the root-owned directory returns permission denied instead of file-not-found.

## Fix

Added `os.IsPermission(err) || errors.Is(err, os.ErrPermission)` to `isConfigFileNotFound()` so both error types trigger graceful fallback to env-only configuration.

Tests added for direct and wrapped permission errors.

Closes #52