### PR TITLE
fix(docker): fix vendor directory missing in Docker build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+## [1.2.1-beta.1](https://github.com/LerianStudio/matcher/compare/v1.2.0...v1.2.1-beta.1) (2026-03-23)
+
 ## [1.2.0](https://github.com/LerianStudio/matcher/compare/v1.1.1...v1.2.0) (2026-03-23)
 
 ## [1.1.1](https://github.com/LerianStudio/matcher/compare/v1.1.0...v1.1.1) (2026-03-22)

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,9 @@ FROM --platform=$BUILDPLATFORM golang:1.26.1-alpine AS builder
 WORKDIR /matcher-app
 
 COPY go.mod go.sum ./
-RUN go mod download && go mod vendor
+RUN go mod download
 COPY . .
+RUN go mod vendor
 
 ARG TARGETARCH
 ARG VERSION=dev


### PR DESCRIPTION
## Summary

- **Fix Docker build failure**: `go mod vendor` was running before `COPY . .`, so the vendor directory was overwritten by the source copy (vendor/ is gitignored and absent from the repo)
- Splits `go mod download` (cached layer) from `go mod vendor` (runs after source copy)

## Root cause

The Dockerfile ran `go mod download && go mod vendor` in a single layer before copying source files. When `COPY . .` ran next, it overlaid the working directory — and since `vendor/` is in `.gitignore`, it effectively deleted the vendored dependencies. The subsequent `go build -mod=vendor` then failed with `import lookup disabled by -mod=vendor`.

## Test plan

- [ ] Docker build succeeds (`docker build .`)
- [ ] CI build job passes