### PR TITLE
fix(discovery): use ProductName instead of ConfigName for extraction metadata.source

### DIFF
--- a/internal/discovery/services/command/extraction_commands_test.go
+++ b/internal/discovery/services/command/extraction_commands_test.go
@@ -25,6 +25,7 @@ func testConnectionEntity() *entities.FetcherConnection {
 		ID:               uuid.New(),
 		FetcherConnID:    "fetcher-conn-1",
 		ConfigName:       "config-1",
+		ProductName:      "matcher",
 		DatabaseType:     "postgresql",
 		Status:           vo.ConnectionStatusAvailable,
 		SchemaDiscovered: true,
@@ -266,7 +267,7 @@ func TestStartExtraction_Success(t *testing.T) {
 	currencyCond := fetcherClient.lastSubmitInput.Filters[configKey]["transactions"]["currency"].(map[string]any)
 	assert.Equal(t, []any{"USD"}, currencyCond["eq"])
 	require.NotNil(t, fetcherClient.lastSubmitInput.Metadata)
-	assert.Equal(t, connection.ConfigName, fetcherClient.lastSubmitInput.Metadata["source"])
+	assert.Equal(t, connection.ProductName, fetcherClient.lastSubmitInput.Metadata["source"])
 }
 
 func TestExtractRequestedColumns(t *testing.T) {

--- a/internal/discovery/services/command/extraction_support.go
+++ b/internal/discovery/services/command/extraction_support.go
@@ -60,11 +60,12 @@ func buildExtractionJobInput(
 	}
 
 	// Build Metadata with required "source" key.
-	// Use ConfigName (user-assigned unique identifier, e.g. "prod-db") rather than
-	// ProductName (human label, e.g. "PostgreSQL 16.2") to ensure unique provenance
-	// when multiple connections share the same engine type.
+	// Use ProductName (the product that owns this connection, e.g. "matcher")
+	// to satisfy Fetcher's product ownership validation (validateProductOwnership).
+	// Fetcher compares metadata.source against connection.ProductName — using
+	// ConfigName here would cause FET-1016 (Product Mismatch).
 	metadata := map[string]any{
-		"source": configName,
+		"source": conn.ProductName,
 	}
 
 	return sharedPorts.ExtractionJobInput{

--- a/internal/discovery/services/command/extraction_support_test.go
+++ b/internal/discovery/services/command/extraction_support_test.go
@@ -17,6 +17,7 @@ func TestExtractionSupport_BuildExtractionJobInput_ConfigNameFallback(t *testing
 
 	conn := testConnectionEntity()
 	conn.ConfigName = ""
+	conn.ProductName = "matcher"
 
 	input, err := buildExtractionJobInput(conn, map[string]any{
 		"transactions": map[string]any{"columns": []string{"id", "amount"}},
@@ -26,7 +27,7 @@ func TestExtractionSupport_BuildExtractionJobInput_ConfigNameFallback(t *testing
 
 	require.NoError(t, err)
 	require.Contains(t, input.MappedFields, conn.FetcherConnID)
-	assert.Equal(t, conn.FetcherConnID, input.Metadata["source"])
+	assert.Equal(t, conn.ProductName, input.Metadata["source"])
 	require.Contains(t, input.Filters, conn.FetcherConnID)
 }
 


### PR DESCRIPTION
## Problem

The Fetcher service validates `metadata.source` against `connection.ProductName` in its `validateProductOwnership` check. The matcher was sending `ConfigName` (the user-assigned connection identifier, e.g. `firmino-matcher-dev-new`) as `metadata.source`, instead of `ProductName` (the owning product, e.g. `matcher`).

This caused **FET-1016 (Product Mismatch)** on every extraction job submission via discovery.

## Root Cause

In `extraction_support.go`, `buildExtractionJobInput` set:
```go
metadata := map[string]any{
    "source": configName, // e.g. "firmino-matcher-dev-new"
}
```

But the Fetcher compares:
```go
if conn.ProductName != source { // "matcher" != "firmino-matcher-dev-new" → FET-1016
}
```

## Fix

Changed `metadata.source` to use `conn.ProductName`:
```go
metadata := map[string]any{
    "source": conn.ProductName, // e.g. "matcher"
}
```

Updated unit tests to reflect the new behavior.

## Testing

- All 1617 unit tests passing in `internal/discovery/...`
- Manually validated by @AugustoAlvarenga against a live Fetcher instance — extraction succeeds with this fix

Requested by: @AugustoAlvarenga